### PR TITLE
Fix pg_curl install

### DIFF
--- a/src/postgres/Dockerfile
+++ b/src/postgres/Dockerfile
@@ -2,13 +2,13 @@
 # Extensions: pg_curl,
 
 FROM postgres:16.1-bullseye
-RUN apt-get update && apt-get -y install git make postgresql-server-dev-all libcurl-ocaml-dev clang 
+RUN apt-get update && apt-get -y install git make postgresql-server-dev-16 libcurl-ocaml-dev clang
 RUN git clone https://github.com/RekGRpth/pg_curl.git
 COPY Makefile pg_curl/Makefile
 RUN cd pg_curl && make && make install
 RUN cd / && \
         rm -rf /pg_cron && \
-        apt-get remove -y git make postgresql-server-dev-all clang && \
+        apt-get remove -y git make postgresql-server-dev-16 clang && \
         apt-get autoremove --purge -y && \
         apt-get clean && \
         apt-get purge


### PR DESCRIPTION
I can reproduce. The dev-all seems to pull in several postgres versions and does an initdb. These conflict. The conflict resolution message during apt install blocks the installation.