### PR TITLE
Relay Node Configuration

### DIFF
--- a/.env.example.mainnet
+++ b/.env.example.mainnet
@@ -65,11 +65,12 @@ CARDANO_NODE_HOME=""
 NODE_EXTENSIONS="{\"name\":\"cardano_node\",\"version\":\"${CARDANO_NODE_VERSION}\",\"image\":\"\"}"
 
 # Ogmios
-OGMIOS_VERSION=v6.11.2
+OGMIOS_VERSION=v6.13.0
 OGMIOS_IMAGE="cardanosolutions/ogmios:${OGMIOS_VERSION}"
 OGMIOS_HOST="cardano-node-ogmios"
 OGMIOS_PORT=${PORT_OFFSET}1337
 #NODE_EXTENSIONS="${NODE_EXTENSIONS},{\"name\":\"ogmios\",\"path\":\"ogmios/\",\"version\":\"${CARDANO_OGMIOS_VERSION}\",\"image\":\"${CARDANO_OGMIOS_IMAGE}\"}"
+CARDANO_NODE_RELAY_PORT=${PORT_OFFSET}3000
 
 
 #Cardano Node + Ogmios

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ___  ____ __ _ ___  ____ _    _ ____ __ _
 
 [ ❤️ Support the Dandelion Network on Catalyst](https://github.com/GameChangerFinance/gamechanger.wallet/blob/main/catalyst/FUND13.md)
 
- #[⚠️⚠️ LATEST UPDATES! ⚠️⚠️](#relay-node-configuration)
+ [⚠️⚠️ LATEST UPDATES! ⚠️⚠️](#relay-node-configuration)
 
 # What's this?
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ ___  ____ __ _ ___  ____ _    _ ____ __ _
 
 [ ❤️ Support the Dandelion Network on Catalyst](https://github.com/GameChangerFinance/gamechanger.wallet/blob/main/catalyst/FUND13.md)
 
+* [LATEST UPDATES!](#relay-node-config)
+
 # What's this?
 
 **Dandelion** is a community-supported project led by GimbaLabs and operated by La PEACEpool Cardano repsist₳nce. Every Cardano API available. From bottom to top, from testnet to mainnet.
@@ -322,3 +324,7 @@ All basic endpoints + **cardano-submit-api** + **ogmios** are supported. Other a
 Default **Blockfrost RYO** support can be examined with it's latest test reports
 - [preprod](tests/blockfrost/preprod.report)
 - [mainnet](tests/blockfrost/mainnet.report)
+
+### Relay Node Configuration
+
+To enable relay capabilities, simply edit the [topology.config](./confgis/cardano/config/network/mainnet/cardano-node/topolgy.json) with your block producer and/or relay IP addresses.  Make sure `valency` value is set to the amount of nodes listed (the example includes a relay and producer entry, therefore is set to `2`).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ___  ____ __ _ ___  ____ _    _ ____ __ _
 
 [ ❤️ Support the Dandelion Network on Catalyst](https://github.com/GameChangerFinance/gamechanger.wallet/blob/main/catalyst/FUND13.md)
 
-* [LATEST UPDATES!](#relay-node-config)
+ [⚠️LATEST UPDATES!](#relay-node-configuration)
 
 # What's this?
 
@@ -327,4 +327,4 @@ Default **Blockfrost RYO** support can be examined with it's latest test reports
 
 ### Relay Node Configuration
 
-To enable relay capabilities, simply edit the [topology.config](./confgis/cardano/config/network/mainnet/cardano-node/topolgy.json) with your block producer and/or relay IP addresses.  Make sure `valency` value is set to the amount of nodes listed (the example includes a relay and producer entry, therefore is set to `2`).
+To enable relay capabilities, simply edit the [topology.config](./configs/cardano/config/network/mainnet/cardano-node/topolgy.json) with your block producer and/or relay IP addresses.  Make sure `valency` value is set to the amount of nodes listed (the example includes a relay and producer entry, therefore is set to `2`).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ ___  ____ __ _ ___  ____ _    _ ____ __ _
 
 [ ❤️ Support the Dandelion Network on Catalyst](https://github.com/GameChangerFinance/gamechanger.wallet/blob/main/catalyst/FUND13.md)
 
- [⚠️LATEST UPDATES!](#relay-node-configuration)
+ #[⚠️⚠️ LATEST UPDATES! ⚠️⚠️](#relay-node-configuration)
 
 # What's this?
 

--- a/README.md
+++ b/README.md
@@ -327,4 +327,4 @@ Default **Blockfrost RYO** support can be examined with it's latest test reports
 
 ### Relay Node Configuration
 
-To enable relay capabilities, simply edit the [topology.config](./configs/cardano/config/network/mainnet/cardano-node/topolgy.json) with your block producer and/or relay IP addresses.  Make sure `valency` value is set to the amount of nodes listed (the example includes a relay and producer entry, therefore is set to `2`).
+To enable relay capabilities, simply edit the [topology.config](./configs/cardano/config/network/mainnet/cardano-node/topology.json) with your block producer and/or relay IP addresses.  Make sure `valency` value is set to the amount of nodes listed (the example includes a relay and producer entry, therefore is set to `2`).

--- a/README.md
+++ b/README.md
@@ -327,4 +327,4 @@ Default **Blockfrost RYO** support can be examined with it's latest test reports
 
 ### Relay Node Configuration
 
-To enable relay capabilities, simply edit the [topology.config](./configs/cardano/config/network/mainnet/cardano-node/topology.json) with your block producer and/or relay IP addresses.  Make sure `valency` value is set to the amount of nodes listed (the example includes a relay and producer entry, therefore is set to `2`).
+To enable relay capabilities, simply edit the [topology.config](./configs/cardano/config/network/mainnet/cardano-node/topology.json) with your block producer (localRoots) and/or relay (publicRoots) IP addresses.  Make sure `valency` value is set to the amount of nodes you list.

--- a/configs/cardano/config/network/mainnet/cardano-node/config.json
+++ b/configs/cardano/config/network/mainnet/cardano-node/config.json
@@ -10,7 +10,7 @@
   "LastKnownBlockVersion-Major": 3,
   "LastKnownBlockVersion-Minor": 0,
   "MaxKnownMajorProtocolVersion": 2,
-  "MinNodeVersion": "8.12.0",
+  "MinNodeVersion": "10.1.4",
   "PeerSharing": true,
   "Protocol": "Cardano",
   "RequiresNetworkMagic": "RequiresNoMagic",

--- a/configs/cardano/config/network/mainnet/cardano-node/topology.json
+++ b/configs/cardano/config/network/mainnet/cardano-node/topology.json
@@ -11,7 +11,7 @@
         {
           "address": "relay-ip_address",
           "port": 6000,
-          "name" "relay"
+          "name": "relay"
         }
       ],
       "advertise": false,

--- a/configs/cardano/config/network/mainnet/cardano-node/topology.json
+++ b/configs/cardano/config/network/mainnet/cardano-node/topology.json
@@ -24,7 +24,7 @@
       ],
       "advertise": false,
       "trustable": true,
-      "valency": 
+      "valency": 1
     }
   ],
   "publicRoots": [

--- a/configs/cardano/config/network/mainnet/cardano-node/topology.json
+++ b/configs/cardano/config/network/mainnet/cardano-node/topology.json
@@ -1,24 +1,22 @@
 {
-  "bootstrapPeers": [
-    {
-      "address": "backbone.cardano.iog.io",
-      "port": 3001
-    },
-    {
-      "address": "backbone.mainnet.emurgornd.com",
-      "port": 3001
-    },
-    {
-      "address": "backbone.mainnet.cardanofoundation.org",
-      "port": 3001
-    }
-  ],
+  "bootstrapPeers": [],
   "localRoots": [
     {
-      "accessPoints": [],
+      "accessPoints": [
+        {
+          "address": "block-producer-ip_address",
+          "port": 6000,
+          "name": "block-producer"
+        },
+        {
+          "address": "relay-ip_address",
+          "port": 6000,
+          "name" "relay"
+        }
+      ],
       "advertise": false,
-      "trustable": false,
-      "valency": 1
+      "trustable": true,
+      "valency": 2
     }
   ],
   "publicRoots": [

--- a/configs/cardano/config/network/mainnet/cardano-node/topology.json
+++ b/configs/cardano/config/network/mainnet/cardano-node/topology.json
@@ -1,5 +1,18 @@
 {
-  "bootstrapPeers": [],
+  "bootstrapPeers": [
+    {
+      "address": "backbone.cardano.iog.io",
+      "port": 3001
+    },
+    {
+      "address": "backbone.mainnet.emurgornd.com",
+      "port": 3001
+    },
+    {
+      "address": "backbone.mainnet.cardanofoundation.org",
+      "port": 3001
+    }
+  ],
   "localRoots": [
     {
       "accessPoints": [

--- a/configs/cardano/config/network/mainnet/cardano-node/topology.json
+++ b/configs/cardano/config/network/mainnet/cardano-node/topology.json
@@ -8,21 +8,22 @@
           "port": 6000,
           "name": "block-producer"
         },
+      ],
+      "advertise": false,
+      "trustable": true,
+      "valency": 
+    }
+  ],
+  "publicRoots": [
+    {
+      "accessPoints": [
         {
           "address": "relay-ip_address",
           "port": 6000,
           "name": "relay"
         }
       ],
-      "advertise": false,
-      "trustable": true,
-      "valency": 2
-    }
-  ],
-  "publicRoots": [
-    {
-      "accessPoints": [],
-      "advertise": false
+      "advertise": true
     }
   ],
   "useLedgerAfterSlot": 128908821

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,8 @@ services:
         max-file: "10"
     ports:
       - ${OGMIOS_PORT:-1337}:1337
+      #Exposes node for relay connections- comment to disable
+      - ${CARDANO_NODE_RELAY_PORT:-3000}:3000 
     environment:
       NETWORK: ${NETWORK}
       #SOCKET: "${CARDANO_NODE_HOME}/ipc/node.socket" 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
       #- node-ipc:/ipc 
       # Uncomment if you want to use your own config files or the provided ones.
       # Current configs are also available at: https://book.world.dev.cardano.org/
-      #- ./configs/cardano/config/network/${NETWORK}:/config
+      - ./configs/cardano/config/network/${NETWORK}:/config
       - node-db:${CARDANO_NODE_HOME}/db
       - node-ipc:${CARDANO_NODE_HOME}/ipc
       - ./scripts/cardano-node-ogmios/:/scripts/


### PR DESCRIPTION
Enables Dandelion-lite's `cardano-node` to be used as a relay node, with all the wonderful APIs on top!  

*Exposed port via Ogmios to enable cardano-node comms
*Removed public peers from topology 
*Added localRoots entries for SPO topology configuration