### PR TITLE
Feat/sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Examples:
 
 - `full-backup-sync.sh` may validate remote metadata, compare versions, decide whether to skip or retry files, and delegate downloads.
 - `backup-sync.sh` should only download one requested backup archive cleanly.
-- `create-backup-checksum.sh` is the canonical local producer of `READY` and `SHA256SUMS`.
+- `create-backup-checksum.sh` is the canonical local producer of `READY`, `MD5SUMS`, and `SHA256SUMS`.
 - `backup-volume.sh` and `restore-volume.sh` should stay narrow volume export/import primitives.
 
 ## Documentation
@@ -126,7 +126,10 @@ Design rules:
 - Let `aria2c` resume before replacing a local file.
 - If a completed transfer still fails checksum verification, wrappers may remove only that single target file and retry once.
 - Hashes are the source of truth; HTTP headers are only an optimization.
-- Remote backup sync must be gated by remote `READY` and `SHA256SUMS`.
+- Remote backup sync must be gated by remote `READY`, `MD5SUMS`, and `SHA256SUMS`.
+- `MD5SUMS` may be used as a fast-change hint to avoid expensive SHA256 hashing before downloads.
+- `SHA256SUMS` remains the final integrity authority and must be regenerated locally after sync before reporting success.
+- If final SHA256 verification fails, move `READY` to `old/READY` instead of deleting it, so the set is clearly marked not-ready.
 - Missing remote `READY` means the remote backup repository is not ready or invalid.
 - `DLT` and `NETWORK` mismatches are hard failures.
 - `CARDANO_NODE_VERSION` and `CARDANO_DB_SYNC_VERSION` mismatches must warn with incoming and local values and require explicit operator intent.
@@ -159,7 +162,7 @@ Goal: keep each backup script understandable and replaceable during incidents.
 - `full-backup-sync.sh`: wrapper that validates remote backup metadata, discovers expected volumes, and delegates payload downloads.
 - `full-backup.sh`: wrapper for creating a local backup set.
 - `full-restore.sh`: wrapper for restoring local backup sets.
-- `create-backup-checksum.sh`: canonical generator for local `READY` and `SHA256SUMS`.
+- `create-backup-checksum.sh`: canonical generator for local `READY`, `MD5SUMS`, and `SHA256SUMS`.
 
 Do not reintroduce `sha256sum-backups.sh`. The canonical checksum script is:
 

--- a/README.md
+++ b/README.md
@@ -58,82 +58,113 @@ Some other experimental, legacy, non-performant APIs, non-compliant with popular
 Each service is containerized and managed via Podman (as an alias of Docker) and orquestrated using Docker Compose, ensuring easy deployment and scalability.
 
 
-## Hardware Requirements (10-10-2024):
+## Hardware Requirements:
+
+**Last updated: 18/06/2026**
 
 Suggested setup for concurrent **Cardano Mainnet** and **Preproduction Testnet** with volume backups consists on
 
 - 128GB RAM (DDR4 ECC RAM)
-- 2TB M2 NVME for storage
+- 2TB M2 NVME for full storage (OS + docker images + volumes + backups)
 - Dual Intel Xeon E5 2680 v4 (LGA 2011-3 motherboard)
 
-### Volume sizes
+### Storage Requirements
+
+<table>
+  <thead>
+    <tr>
+      <th>network</th>
+      <th>service</th>
+      <th>volume size</th>
+      <th>total volume size</th>
+      <th>backup size</th>
+      <th>total backup size</th>
+      <th>total</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td rowspan="5">mainnet</td>
+      <td>db-sync-data</td>
+      <td>25G</td>
+      <td rowspan="5">724.23G</td>
+      <td>1.4G</td>
+      <td rowspan="5">357.385G</td>
+      <td rowspan="5">~1.08T</td>
+    </tr>
+    <tr>
+      <td>node-db</td>
+      <td>187G</td>
+      <td>120G</td>
+    </tr>
+    <tr>
+      <td>node-ipc</td>
+      <td>8.0K</td>
+      <td>92</td>
+    </tr>
+    <tr>
+      <td>postgresdb</td>
+      <td>512G</td>
+      <td>236G</td>
+    </tr>
+    <tr>
+      <td>unimatrix-data</td>
+      <td>8.0K</td>
+      <td>92</td>
+    </tr>
+    <tr>
+      <td rowspan="5">preprod</td>
+      <td>db-sync-data</td>
+      <td>3.9G</td>
+      <td rowspan="5">27.94G</td>
+      <td>1.4G</td>
+      <td rowspan="5">24.585G</td>
+      <td rowspan="5">~52.5G</td>
+    </tr>
+    <tr>
+      <td>node-db</td>
+      <td>8.8G</td>
+      <td>8.2G</td>
+    </tr>
+    <tr>
+      <td>node-ipc</td>
+      <td>8.0K</td>
+      <td>92</td>
+    </tr>
+    <tr>
+      <td>postgresdb</td>
+      <td>16G</td>
+      <td>15G</td>
+    </tr>
+    <tr>
+      <td>unimatrix-data</td>
+      <td>8.0K</td>
+      <td>92</td>
+    </tr>
+  </tbody>
+</table>
+
+**Important**: Container image sizes and OS footprint not listed on table
+
+Full volumes download (sync), backup and restore procedures can be run manually by helper scripts or using the menu on `$ ./scripts/dandoman.sh`.
+
+### Volume sizes (mandatory)
 
 These are sizes of the volumes used by the containers of recent production deployments.
 
-Using: `$ ./scripts/docker/list-volume-sizes.sh`
-
-Last updated: 10/10/2024
-
-### Cardano Mainnet   
-
-    25G     gc-node-mainnet_db-sync-data
-    445M    gc-node-mainnet_dbless-cardano-token-registry-data
-    187G    gc-node-mainnet_node-db
-    8.0K    gc-node-mainnet_node-ipc
-    512G    gc-node-mainnet_postgresdb
-    8.0K    gc-node-mainnet_unimatrix-data
-
-    Total   724.43 GB
-
-### Cardano Pre-Production Testnet
-
-    3.9G    gc-node-preprod_db-sync-data
-    41M     gc-node-preprod_dbless-cardano-token-registry-data
-    8.8G    gc-node-preprod_node-db
-    8.0K    gc-node-preprod_node-ipc
-    16G     gc-node-preprod_postgresdb
-    8.0K    gc-node-preprod_unimatrix-data
-
-    Total   28.74 GB
+Get them using: `$ ./scripts/docker/list-volume-sizes.sh`
 
 
-### Volume Backup Sizes
+### Volume Backup Sizes (optional)
 
-These are sizes of compressed backups of container volumes on recent production deployments. Is not estrictly required to take these disk space lists into consideration for hardware adquisition but is adviced as working without snapshots can delay node syncing times even for more than a week.
+These are sizes of compressed backups of container volumes on recent production deployments. Is not estrictly required to take these disk space lists into consideration for hardware adquisition but is adviced as working without backup snapshots can delay node syncing times even for more than a week.
 
-Full volumes backup and restore procedures can be run manually by helper scripts or using the menu on `$ ./scripts/dandoman.sh`.
-
-Last updated: 10/10/2024
-
-### Cardano Mainnet
-        
-    17G     db-sync-data.tar.gz
-    97G     node-db.tar.gz
-    4.0K    node-ipc.tar.gz
-    12K     pgadmin-data.tar.gz
-    4.0K    portainer-data.tar.gz
-    137G    postgresdb.tar.gz
-    4.0K    unimatrix-data.tar.gz
-    
-    Total   250G
+Get them with integrity hashes and local deployment metadata using: `$ ./scripts/docker/create-backup-checksum.sh`
 
 
-### Cardano Pre-Production Testnet
-   
-    
-    1.7G    db-sync-data.tar.gz
-    3.8G    node-db.tar.gz
-    4.0K    node-ipc.tar.gz
-    12K     pgadmin-data.tar.gz
-    4.0K    portainer-data.tar.gz
-    3.8G    postgresdb.tar.gz
-    4.0K    unimatrix-data.tar.gz
+## Software Requirements:
 
-    Total   9.3G
-
-## Software Requirements (10-10-2024):
-
-Reported to be working on:
+Reported to be working in production on:
 
 - Ubuntu Server version 24.04 (normal, not minimal install)
 
@@ -141,7 +172,9 @@ Reported to be working on:
 
 ### Base system install
 
-As a base system we use **ubuntu-server version 24.04**. We use the normal install not the minimal one. Also install **OpenSSH** server to allow for system administration. 
+As suggested base system you can use **ubuntu-server**. 
+
+We use the normal install not the minimal one. Also install **OpenSSH** server to allow for system administration. 
 
 1. When install is completed do `ip -br a` to get the ip address of your newly installed server 
 2. From you local system. So not on your server do `ssh-copy-id USER_NAME@SERVER_IP` This will copy your ssh keys to the server to allow easy login
@@ -162,9 +195,6 @@ docker inspect --format "{{json .State.Health }}" dandolite-preprod-cardano-node
 
 # Check if db-sync is ready 
 docker inspect --format "{{json .State.Health }}" dandolite-preprod-cardano-db-sync-1 | jq
-
-# Koios tip check
-curl http://127.0.0.1:8050/koios/v1/tip
 ```
 
 Remember to secure your deployment according to best practices, including securing your database and API endpoints.
@@ -179,7 +209,7 @@ To auto run on system start:
 
 Syncing Cardano node and databases can take even more than a week, it is adviced for you to download compressed snapshots of the databases to get you started.
 
-Remote backup syncs are guarded by the special `READY` metadata file plus `MD5SUMS` fast-checks and `SHA256SUMS` integrity hashes published beside the backup archives. If `READY` file exists it will be interpreted as a standby flag for third party operators to sync with the published files. `READY` content must match the local `DLT` and `NETWORK` environment variables; Cardano node and db-sync version differences are shown as explicit warnings because they may be valid only during planned upgrade workflows. The downloader uses `MD5SUMS` to quickly decide whether files need syncing, then regenerates local `SHA256SUMS` and compares it with remote payload hashes before reporting success. If the final SHA verification fails, `READY` is moved into `old/READY` so the set is not advertised as ready. Make your own backups, files are meant to be overwritten!
+#### Instructions
 
 1. Set the `BACKUP_DIR` environment variable on `.env` file with the location on where you want to store the files, like `BACKUP_DIR="/home/${USER}/backups/${NETWORK}/"`. Check [Volume Backup Sizes](#volume-backup-sizes) for estimating the required size.
 2. Execute `scripts/dandoman.sh` > `Setup->Download Backup` and follow steps.
@@ -194,17 +224,26 @@ Press key to continue.. (Ctrl + C to abort)
 ✅ All done.
 ```
 
+
+#### Behavior
+Remote backup syncs are guarded by the special `READY` metadata file plus `MD5SUMS` fast-checks and `SHA256SUMS` integrity hashes published beside the backup archives. 
+
+If `READY` file exists it will be interpreted as a standby flag for third party operators to sync with the published files. `READY` content must match the local `DLT` and `NETWORK` environment variables; Cardano node and db-sync version differences are shown as explicit warnings because they may be valid only during planned upgrade workflows. The downloader uses `MD5SUMS` to quickly decide whether files need syncing, then regenerates local `SHA256SUMS` and compares it with remote payload hashes before reporting success. 
+
+If the final SHA verification fails, `READY` is moved into `old/READY` so the set is not advertised as ready. Make your own backups, files are meant to be overwritten!
+
+
 ### Run a Full Deploy Backup
 
 Syncing Cardano node and databases can take even more than a week, it is adviced for you to take compressed snapshots or backups of your databases after 2 or 3 of months at least.
-1. Set the `BACKUP_DIR` environment variable on `.env` file with the location on where you want to store the files, like `BACKUP_DIR="/home/${USER}/backups/${NETWORK}/"`. Check [Volume Backup Sizes](#volume-backup-sizes) for estimating the required size.
+1. Set the `BACKUP_DIR` environment variable on `.env` file with the location on where you want to store the files, like `BACKUP_DIR="/home/${USER}/backups/${NETWORK}/"`. Check [Volume Backup Sizes](###-storage-requirements) for estimating the required size.
 2. Customize `NGINX_WWW_BACKUP_USER` and `NGINX_WWW_BACKUP_PASSWORD` to protect with a password the hosting of your backup files
 3. Execute `scripts/dandoman.sh` > `Setup->Full backup` and follow steps. The backup flow will also create the special `READY`, `MD5SUMS`, and `SHA256SUMS` files (you can do manually by calling `./scripts/docker/create-backup-checksum.sh`).
 
 ### Run a Full Deploy Restore
 
 This will **WIPE ALL YOUR DEPLOYMENT DATA** and will restore a previous backup:
-1. Set the `BACKUP_DIR` environment variable on `.env` file with the location from where you want to read the stored files, like `BACKUP_DIR="/home/${USER}/backups/${NETWORK}/"`. Check [Volume Backup Sizes](#volume-backup-sizes) for estimating the required size.
+1. Set the `BACKUP_DIR` environment variable on `.env` file with the location from where you want to read the stored files, like `BACKUP_DIR="/home/${USER}/backups/${NETWORK}/"`. Check[Volume Backup Sizes](###-storage-requirements)  for estimating the required size.
 2. Execute `scripts/dandoman.sh` > `Setup->Full restore` and follow steps.
 
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ To auto run on system start:
 
 Syncing Cardano node and databases can take even more than a week, it is adviced for you to download compressed snapshots of the databases to get you started.
 
-Remote backup syncs are guarded by the special `READY` (metadata) and `SHA256SUMS` (integrity hashes) files published beside the backup archives. If `READY` file exists it will be interpreted as a standy flag for third party operators to sync with the published files. `READY` content must match the local `DLT` and `NETWORK` environment variables; Cardano node and db-sync version differences are shown as explicit warnings because they may be valid only during planned upgrade workflows. The downloader uses `aria2c` to resume partial files overwriting existing files and without creating temporary files for disk usage optimization. Make your own backups, files are meant to be overwritten!
+Remote backup syncs are guarded by the special `READY` metadata file plus `MD5SUMS` fast-checks and `SHA256SUMS` integrity hashes published beside the backup archives. If `READY` file exists it will be interpreted as a standby flag for third party operators to sync with the published files. `READY` content must match the local `DLT` and `NETWORK` environment variables; Cardano node and db-sync version differences are shown as explicit warnings because they may be valid only during planned upgrade workflows. The downloader uses `MD5SUMS` to quickly decide whether files need syncing, then regenerates local `SHA256SUMS` and compares it with remote payload hashes before reporting success. If the final SHA verification fails, `READY` is moved into `old/READY` so the set is not advertised as ready. Make your own backups, files are meant to be overwritten!
 
 1. Set the `BACKUP_DIR` environment variable on `.env` file with the location on where you want to store the files, like `BACKUP_DIR="/home/${USER}/backups/${NETWORK}/"`. Check [Volume Backup Sizes](#volume-backup-sizes) for estimating the required size.
 2. Execute `scripts/dandoman.sh` > `Setup->Download Backup` and follow steps.
@@ -199,7 +199,7 @@ Press key to continue.. (Ctrl + C to abort)
 Syncing Cardano node and databases can take even more than a week, it is adviced for you to take compressed snapshots or backups of your databases after 2 or 3 of months at least.
 1. Set the `BACKUP_DIR` environment variable on `.env` file with the location on where you want to store the files, like `BACKUP_DIR="/home/${USER}/backups/${NETWORK}/"`. Check [Volume Backup Sizes](#volume-backup-sizes) for estimating the required size.
 2. Customize `NGINX_WWW_BACKUP_USER` and `NGINX_WWW_BACKUP_PASSWORD` to protect with a password the hosting of your backup files
-3. Execute `scripts/dandoman.sh` > `Setup->Full backup` and follow steps. The backup flow will also create the special `READY` and `SHA256SUMS` files (you can do manually by calling `./scripts/docker/create-backup-checksum.sh`).
+3. Execute `scripts/dandoman.sh` > `Setup->Full backup` and follow steps. The backup flow will also create the special `READY`, `MD5SUMS`, and `SHA256SUMS` files (you can do manually by calling `./scripts/docker/create-backup-checksum.sh`).
 
 ### Run a Full Deploy Restore
 

--- a/docs/plan-example.md
+++ b/docs/plan-example.md
@@ -1,18 +1,21 @@
-# Backup Sync Refactor Plan
+# Backup Sync Master Plan
 
-Date: 2026-06-17
+Date: 2026-06-18
 
 ## Goal
 
 Refactor the backup distribution workflow so local backup mirrors can self-heal safely, resume partial downloads, avoid duplicate disk use, and expose a reusable per-volume sync command without breaking existing human or script entrypoints.
 
+The implementation must also reduce operator wait time on huge backup sets by using `MD5SUMS` as a fast precheck while keeping `SHA256SUMS` as the final integrity authority.
+
 The updated tactic is:
 
-- wrapper-level sync orchestration must be governed by remote `READY` and hash files
+- wrapper-level sync orchestration must be governed by remote `READY`, `MD5SUMS`, and `SHA256SUMS`
 - low-level download helpers must remain simple, direct, and emergency-fallback friendly
 - wrappers must be the battle-tested daily path
-- metadata must be easy to parse in shell and safe to validate before any download work starts
+- metadata must be easy to parse in shell and safe to validate before any payload download starts
 - keep code changes surgical and avoid modifying `full-backup.sh`, `full-restore.sh`, `restore-volume.sh`, `dandoman.sh`, and other working scripts unless a change is genuinely required
+- when final SHA verification fails, do not advertise the set as ready; move `READY` into `old/READY` instead of deleting it so operators can inspect the failed published metadata
 
 ## Non-Negotiables
 
@@ -28,19 +31,20 @@ The updated tactic is:
 - Centralize local `READY` and checksum publication in `scripts/docker/create-backup-checksum.sh` so backup-set generation always goes through one canonical manifest path.
 - Rename `scripts/docker/sha256sum-backups.sh` to `scripts/docker/create-backup-checksum.sh` and make that the canonical script for local `READY` and checksum generation.
 - Update every script, doc, help text, and inline example across the repo that references `sha256sum-backups.sh` so they consistently reference `create-backup-checksum.sh`.
+- Preserve the current operator-friendly logging, emoji convention, and error wording style.
 
 ## Current Touch Points
 
 - `scripts/docker/full-backup-sync.sh`
+- `scripts/docker/backup-sync.sh`
+- `scripts/docker/create-backup-checksum.sh`
 - `scripts/docker/backup-volume.sh`
 - `scripts/docker/restore-volume.sh`
-- `scripts/docker/create-backup-checksum.sh`
 - `scripts/docker/full-backup.sh`
 - `scripts/docker/full-restore.sh`
 - `README.md`
-- `AdminTool.md`
 - `scripts/docker/README.md`
-- `scripts/dandoman.sh`
+- local `AGENTS.md`
 
 ## Target Design
 
@@ -48,20 +52,20 @@ The updated tactic is:
 
 - `backup-volume.sh` remains the low-level volume export helper.
 - `restore-volume.sh` remains the low-level volume import helper.
-- `backup-sync.sh` becomes the low-level per-volume remote sync helper.
-- `full-backup-sync.sh` becomes a thin wrapper that discovers target volumes and delegates each file download to `backup-sync.sh`.
-- `create-backup-checksum.sh` becomes the integrity manifest generator and verifier companion for backup directories.
+- `backup-sync.sh` stays the low-level per-volume remote sync helper.
+- `full-backup-sync.sh` remains the wrapper that discovers target volumes and delegates each file download to `backup-sync.sh`.
+- `create-backup-checksum.sh` becomes the canonical integrity manifest generator for backup directories.
 - All existing doc and script references to the old checksum helper name must be updated in the same change so the repo stays consistent.
 
-### 1a. Make the wrapper authoritative
+### 2. Make the wrapper authoritative
 
-- `full-backup-sync.sh` must inspect remote `READY` and hash files before syncing any payload.
+- `full-backup-sync.sh` must inspect remote `READY`, `MD5SUMS`, and `SHA256SUMS` before syncing any payload.
 - If remote `READY` is missing, the remote repository is invalid or not ready and the wrapper must fail fast.
-- If remote `READY` exists but its `network` and `dlt` values do not match the local deployment environment, the wrapper must halt with an error.
-- If remote `READY` matches `network` and `dlt` but `node` or `dbsync` versions differ from local values, the wrapper must warn loudly in uppercase and continue only if that is an intentional upgrade path.
+- If remote `READY` exists but its `NETWORK` and `DLT` values do not match the local deployment environment, the wrapper must halt with an error.
+- If remote `READY` matches `NETWORK` and `DLT` but `CARDANO_NODE_VERSION` or `CARDANO_DB_SYNC_VERSION` differ from local values, the wrapper must warn loudly in uppercase and continue only if that is an intentional upgrade path.
 - The low-level downloader must not own deployment policy; it only downloads one file cleanly when told to do so.
 
-### 2. Make sync idempotent and self-healing
+### 3. Make sync idempotent and self-healing
 
 - If a local backup file is complete and matches remote content, keep it.
 - If a local backup file is partial, resume it.
@@ -71,52 +75,41 @@ The updated tactic is:
 - Never create temporary duplicate backup files alongside the target artifact.
 - Never rely on rename-based fallback copies such as `.1`, `.2`, `.3`.
 - Use the final backup filename as the only on-disk target for any in-progress download.
-- On wrapper startup, remove any stale local `READY` and hash file before beginning a fresh remote sync pass.
-
-### 3. Avoid duplicate files
-
-- Configure `aria2c` so it does not create `.1`, `.2`, `.3` copies.
-- Prefer in-place reuse of the target filename.
-- Use resumable downloads directly into the destination path.
-- If a file cannot be validated with confidence, do not add a second copy as a fallback.
+- On wrapper startup, remove any stale local `READY`, `MD5SUMS`, and `SHA256SUMS` before beginning a fresh remote sync pass.
 
 ### 4. Add a stable manifest layer
 
-- Rename the metadata sidecar to `READY`.
 - Publish a constant `READY` file alongside the backup files.
 - Use it to record deployment metadata such as:
-  - network tag
-  - DLT tag
-  - node version
-  - dbsync version
-  - source generation timestamp
-  - optional source endpoint
+  - `DLT`
+  - `NETWORK`
+  - `CARDANO_NODE_VERSION`
+  - `CARDANO_DB_SYNC_VERSION`
+  - `UPDATED_AT`
+  - optional source endpoint or local-context fields when needed
 - Make `READY` plain key-value text that is easy to parse with bash.
-- Make `READY` plain key-value text-safe against human dummy whitespace errors.
-- Make `READY` match the remote version verbatim after sync.
+- Make `READY` position-agnostic and safe against human whitespace errors.
+- Make `READY` match the remote version verbatim after sync, while allowing the wrapper to update only explicit local-context fields when required.
 - Publish hashes in the standard uppercase `SHA256SUMS` file name.
-- Use the standard GNU `sha256sum` untagged format so humans and scripts can verify and compare backup sets consistently.
+- Publish a standard uppercase `MD5SUMS` file as a fast-change hint for reruns.
+- Use the standard GNU `sha256sum` and `md5sum` untagged formats so humans and scripts can verify and compare backup sets consistently.
 - Do not embed deployment metadata in the checksum lines themselves.
-- Keep metadata in the separate `READY` file, and include `READY` in the checksum manifest so it is integrity-protected.
-- Have `scripts/docker/create-backup-checksum.sh` generate both `READY` and `SHA256SUMS` for local backup sets.
-- Update every example command, script call site, and doc reference to the new script name so there is no mixed naming in the repo.
+- Keep metadata in the separate `READY` file, and include `READY` in both checksum manifests so it is integrity-protected.
+- Have `scripts/docker/create-backup-checksum.sh` generate `READY`, `MD5SUMS`, and `SHA256SUMS` for local backup sets.
 
 ## Proposed File Behavior
 
 ### `scripts/docker/backup-sync.sh`
 
-- Accept one volume name and one backup directory path, with the same style as `restore-volume.sh`.
-- Derive the file name from the volume name when needed, or accept an explicit backup file stem if the existing calling pattern requires it.
+- Keep the current public call signature stable.
+- Stay as close as possible to a plain download primitive, so the script can also be used as an emergency fallback by humans or other scripts.
 - Download only the requested volume backup file.
 - Prefer a single stable output path.
 - Resume partial downloads.
-- Validate the final file against available remote metadata or local hash manifests.
-- Exit non-zero on validation failure.
-- Use aria2 with the conservative no-duplicate settings: `--continue=true`, `--always-resume=false`, `--auto-file-renaming=false`, and any other flags needed to keep all writes on the final target path.
-- Treat server headers as an optimization only, not as the source of truth.
-- Treat the checksum manifest as the source of truth for deciding whether a local file is already valid.
-- Stay as close as possible to a plain download primitive, so the script can also be used as an emergency fallback by humans or other scripts.
-- If validation proves a file is stale or corrupt, prefer resuming against the existing target with aria2 resume metadata first, and only overwrite after the resume attempt has been exhausted or the file still fails verification.
+- Use aria2 with conservative no-duplicate settings so writes stay on the final target path.
+- Do not make deployment-policy decisions here.
+- Do not parse remote manifests here.
+- Exit non-zero on transfer failure.
 
 ### `scripts/docker/full-backup-sync.sh`
 
@@ -125,23 +118,30 @@ The updated tactic is:
 - Delegate the download of each volume file to `backup-sync.sh`.
 - Keep orchestration logic thin and readable.
 - Preserve current user-facing messaging style.
-- Enforce remote `READY` and `SHA256SUMS` policy before syncing any payloads.
-- Remove stale local `READY` and `SHA256SUMS` files before starting a fresh sync pass.
-- After all downloads finish, fetch and publish the remote `READY` and `SHA256SUMS` files verbatim.
+- Enforce remote `READY`, `MD5SUMS`, and `SHA256SUMS` policy before syncing any payloads.
+- Use remote `MD5SUMS` as the fast precheck to decide whether a local file likely needs a download.
+- If a file already matches remote MD5, skip re-download.
+- If a file does not match remote MD5, let `backup-sync.sh` try to resume/update the target first.
+- After all downloads finish, run `create-backup-checksum.sh` locally to generate accurate local `READY`, `MD5SUMS`, and `SHA256SUMS`.
+- Compare final local `SHA256SUMS` against the remote published `SHA256SUMS`.
+- If the final SHA256 comparison fails, move `READY` to `old/READY` so the set is not advertised as ready yet, and exit non-zero.
 
 ### `scripts/docker/create-backup-checksum.sh`
 
 - Keep its current public call signature and design simplicity.
-- Generate a normalized manifest for the backup directory using the standard `sha256sum` untagged output format.
+- Generate normalized manifests for the backup directory using standard checksum output formats.
 - Generate the local `READY` file from `.env`/deployment values before writing hashes.
-- Include the constant `READY` file in the manifest if present (do not exclude any present file).
+- Include the constant `READY` file in the manifests if present.
 - Avoid shell globs that accidentally include unrelated or transient files.
-- Do not change the checksum line format to smuggle metadata into the digest file.
-- Example line format:
+- Do not change checksum line formats to smuggle metadata into the digest files.
+- Log file names and sizes in a human-friendly way.
+- If the wrapper provides remote `READY` source values, preserve them and only update explicit local-context fields such as `UPDATED_AT`.
 
-  ```text
-  <sha256-hex>  <filename>
-  ```
+### `scripts/docker/full-backup.sh`
+
+- Keep its current public call signature unless a change is genuinely required.
+- Use `create-backup-checksum.sh` as the canonical local manifest generator.
+- Do not introduce unrelated behavior changes.
 
 ## Metadata Strategy
 
@@ -157,14 +157,15 @@ Parsing rule:
 
 - `READY` parsing must be position-agnostic.
 - Any key order is valid as long as the required keys are present exactly once.
-- The parser may ignore blank lines and comment lines, but it must not depend on a fixed line order.
+- Blank lines and comment lines may be ignored.
 - Validation must fail if a required key is missing or duplicated.
 
 Preferred approach:
 
 - publish `READY` as plain `key=value` lines
 - publish one hash manifest for all backup artifacts in the directory using the standard `SHA256SUMS` file name
-- make the hash file deterministic so it can be re-used by humans and automation
+- publish `MD5SUMS` as a fast-change hint for sync reruns
+- make the hash files deterministic so they can be re-used by humans and automation
 - keep metadata and checksums separate so `sha256sum -c` remains compatible
 - make metadata keys stable and shell-friendly
 - do not invent a new postgres version env var if the repository does not already define one in `.env.example*`
@@ -181,23 +182,25 @@ Suggested `READY` keys:
 ## Implementation Order
 
 1. Inspect and stabilize argument parsing and stderr usage in the target scripts.
-2. Define the `READY` contract and the exact hash-file naming convention.
-3. Introduce `backup-sync.sh` as a standalone per-volume downloader.
-4. Refactor `full-backup-sync.sh` to gate on remote `READY` and hash files, then delegate to the new helper.
-5. Rename `sha256sum-backups.sh` to `create-backup-checksum.sh`, then update it to emit normalized manifest data and generate the local `READY` file as the single source of truth for backup-set publication.
+2. Define the `READY` contract and the exact checksum file naming convention.
+3. Keep `backup-sync.sh` as a standalone per-volume downloader with no policy logic.
+4. Refactor `full-backup-sync.sh` to gate on remote `READY`, `MD5SUMS`, and `SHA256SUMS`, then delegate downloads to the low-level helper.
+5. Ensure `create-backup-checksum.sh` emits `READY`, `MD5SUMS`, and `SHA256SUMS` canonically for local backup sets.
 6. Update `full-backup.sh` and `full-restore.sh` only where they need to consume the new manifest conventions.
-7. Update docs and operator help text.
+7. Update docs and operator help text, including `README.md`, `scripts/docker/README.md`, and local `AGENTS.md`.
 8. Add regression tests and fixture coverage for:
    - missing arguments
    - resumed download behavior
    - exact filename reuse
    - remote READY gate failures
+   - MD5 fast-check skip behavior
    - network/DLT mismatch failures
    - upgrade warnings for node/dbsync version drift
    - manifest generation
    - verification failure paths
    - interruption and resume behavior for partially downloaded files
    - overwrite behavior when a stale local file exists
+   - moving `READY` into `old/READY` on final SHA failure
 
 ## Verification Plan
 
@@ -207,17 +210,20 @@ Suggested `READY` keys:
 - Validate that the standalone `backup-sync.sh` works independently for one volume.
 - Validate that backup verification fails loudly when hashes do not match.
 - Validate that interrupted downloads resume into the same destination filename without creating `.1` copies.
-- Validate that a file already matching the manifest is skipped rather than downloaded again.
+- Validate that a file already matching `MD5SUMS` is skipped rather than downloaded again.
 - Validate that checksum verification uses the exact `sha256sum` line format and accepts the published `READY` sidecar separately.
 - Validate that missing remote `READY` causes wrapper failure before any payload downloads.
-- Validate that mismatched `network` or `dlt` causes wrapper failure.
-- Validate that mismatched `node_version` or `dbsync_version` produces uppercase warnings and still requires explicit operator intent.
-- Validate that `READY` and `SHA256SUMS` are re-fetched and published only after all payload files finish successfully.
+- Validate that missing remote `MD5SUMS` or `SHA256SUMS` causes wrapper failure before any payload downloads.
+- Validate that mismatched `NETWORK` or `DLT` causes wrapper failure.
+- Validate that mismatched `CARDANO_NODE_VERSION` or `CARDANO_DB_SYNC_VERSION` produces uppercase warnings and still requires explicit operator intent.
+- Validate that `READY`, `MD5SUMS`, and `SHA256SUMS` are re-fetched and published only after all payload files finish successfully.
 - Run interruption-resume tests with a deliberately interrupted download and confirm the next run resumes instead of starting over.
 - Run overwrite tests with a stale local file and confirm aria2 resume metadata is tried before the target file is replaced.
 - Run the full sync workflow with locally installed `aria2c`; do not ship until that path has been exercised successfully.
-- Validate that the renamed `create-backup-checksum.sh` entrypoint is still called by the full backup flow and produces the same `READY` plus `SHA256SUMS` artifacts.
+- Validate that the renamed `create-backup-checksum.sh` entrypoint is still called by the full backup flow and produces the same `READY`, `MD5SUMS`, and `SHA256SUMS` artifacts.
 - Validate that no repo docs, scripts, or examples still mention `sha256sum-backups.sh` after the rename.
+- Validate that a final SHA mismatch moves `READY` into `old/READY` and leaves the rest of the files intact for inspection.
+- Validate the wrapper and low-level helper with a wrong or failing URL to ensure no local files are harmed by broken remote endpoints.
 
 ## Risks To Watch
 
@@ -228,6 +234,7 @@ Suggested `READY` keys:
 - A wrapper that checks remote metadata too aggressively can block valid mirror refreshes if the metadata server is temporarily inconsistent.
 - Uppercase warning output must remain readable and not become noise during normal upgrade workflows.
 - Parsing `READY` must stay trivial for bash; avoid clever formats that require extra tools.
+- Preserving `READY` in `old/READY` on failure must not accidentally advertise a broken set as usable.
 
 ## Acceptance Criteria
 
@@ -236,8 +243,12 @@ Suggested `READY` keys:
 - A complete matching backup file is not downloaded again.
 - A mismatched backup file is replaced or re-synced safely.
 - No `.1`, `.2`, `.3` duplicate backup artifacts are created during sync.
-- A stable `READY` artifact and normalized `SHA256SUMS` manifest are published alongside backups.
+- A stable `READY` artifact plus normalized `MD5SUMS` and `SHA256SUMS` manifests are published alongside backups.
 - The sync path is available both as a per-volume command and as a full-project wrapper.
 - The wrapper refuses to sync from a remote that lacks `READY`.
-- The wrapper refuses to sync when `network` or `dlt` diverges from local deployment values.
+- The wrapper refuses to sync when `NETWORK` or `DLT` diverges from local deployment values.
 - The wrapper warns loudly on node/dbsync version drift but keeps the upgrade path explicit.
+- The wrapper uses `MD5SUMS` to avoid unnecessary re-downloads.
+- The wrapper still validates final integrity with `SHA256SUMS`.
+- A final SHA failure moves `READY` into `old/READY` instead of deleting it.
+- The docs and AGENTS files explain the fast-check flow and the operator expectations clearly.

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -26,6 +26,7 @@ Published backup sets must include these files beside the `.tar.gz` archives:
 
 ```text
 READY
+MD5SUMS
 SHA256SUMS
 ```
 
@@ -41,7 +42,13 @@ UPDATED_AT=2026-06-17T00:00:00Z
 
 `READY` parsing is position-agnostic. Key order may vary, blank lines and comment lines are ignored, and required keys must appear exactly once.
 
-`SHA256SUMS` uses the standard `sha256sum` format:
+`MD5SUMS` uses the standard `md5sum` format and is used only as a fast-change hint before downloads:
+
+```text
+<md5-hex>  <filename>
+```
+
+`SHA256SUMS` uses the standard `sha256sum` format and remains the final integrity authority:
 
 ```text
 <sha256-hex>  <filename>
@@ -56,22 +63,24 @@ sha256sum -c SHA256SUMS
 
 ## Sync Safety
 
-`full-backup-sync.sh` treats remote `READY` and `SHA256SUMS` as the authority before downloading payload files.
+`full-backup-sync.sh` treats remote `READY`, `MD5SUMS`, and `SHA256SUMS` as the published backup contract. `MD5SUMS` is used to quickly decide whether a local file needs a download. `SHA256SUMS` is regenerated locally after sync and compared against the remote payload hashes before success is reported.
 
 Validation behavior:
 
 - missing remote `READY`: fail before payload downloads
+- missing remote `MD5SUMS`: fail before payload downloads
 - missing remote `SHA256SUMS`: fail before payload downloads
 - remote `DLT` mismatch: fail with incoming and local values
 - remote `NETWORK` mismatch: fail with incoming and local values
 - `CARDANO_NODE_VERSION` mismatch: warn with incoming and local values
 - `CARDANO_DB_SYNC_VERSION` mismatch: warn with incoming and local values
+- final SHA256 mismatch: move `READY` into `old/READY` and fail so the backup set is not advertised as ready
 
 Version mismatches require explicit operator intent. In an interactive shell, type `OK` when prompted. For planned non-interactive upgrade flows, set `ALLOW_BACKUP_VERSION_MISMATCH=1` only for that command invocation.
 
 The payload downloader uses `aria2c` with file auto-renaming disabled. It writes to the final target filename and must not create duplicate backup files such as `.1`, `.2`, or `.3`.
 
-If a local file already matches `SHA256SUMS`, it is skipped. If it is partial or stale, the downloader first lets `aria2c` try to resume/update the existing target. Only after a completed transfer still fails hash validation does it remove that single target file and retry once from zero.
+If a local file already matches `MD5SUMS`, it is skipped quickly. If it is partial or stale, the downloader first lets `aria2c` try to resume/update the existing target. Only after a completed transfer still fails the MD5 fast-check does it remove that single target file and retry once from zero. After all downloads finish, local `SHA256SUMS` is regenerated and compared against the remote payload hashes.
 
 ## Scripts
 
@@ -113,7 +122,7 @@ Full remote backup sync wrapper.
 ./scripts/docker/full-backup-sync.sh <remoteBackupURL> <projectNamePrefix> <backupDir> [user] [password]
 ```
 
-It validates remote `READY` and `SHA256SUMS`, discovers project volumes, then delegates each archive download to `backup-sync.sh`.
+It validates remote `READY`, `MD5SUMS`, and `SHA256SUMS`, discovers project volumes, then delegates each archive download to `backup-sync.sh`.
 
 ### `full-backup.sh`
 
@@ -123,7 +132,7 @@ Full local backup wrapper.
 ./scripts/docker/full-backup.sh <projectNamePrefix> <backupDir>
 ```
 
-It stops services for a clean backup, exports matching volumes, restores the local database password, then calls `create-backup-checksum.sh` to publish `READY` and `SHA256SUMS`.
+It stops services for a clean backup, exports matching volumes, restores the local database password, then calls `create-backup-checksum.sh` to publish `READY`, `MD5SUMS`, and `SHA256SUMS`.
 
 ### `full-restore.sh`
 
@@ -143,7 +152,7 @@ Canonical metadata and checksum generator.
 ./scripts/docker/create-backup-checksum.sh [backupDir]
 ```
 
-It reads the local `.env`, writes `READY`, and creates a standard `SHA256SUMS` manifest for `READY` and all `.tar.gz` files in the backup directory.
+It reads the local `.env`, writes `READY`, and creates standard `MD5SUMS` and `SHA256SUMS` manifests for `READY` and all `.tar.gz` files in the backup directory.
 
 ### `db-sync-snapshot-sync.sh`
 

--- a/scripts/docker/create-backup-checksum.sh
+++ b/scripts/docker/create-backup-checksum.sh
@@ -16,10 +16,13 @@ backupDir=${1:-${BACKUP_DIR:-}}
 
 [[ -z $backupDir ]] && echo "❌ Missing BACKUP_DIR (with trailing slash). $usage" >&2 && exit 1
 [[ ! -d $backupDir ]] && echo "❌ BACKUP_DIR does not exist: '$backupDir'" >&2 && exit 1
+command -v md5sum >/dev/null 2>&1 || { echo "❌ Missing md5sum command. Install dependencies with ./scripts/dandoman.sh before creating backup checksums." >&2; exit 1; }
+command -v sha256sum >/dev/null 2>&1 || { echo "❌ Missing sha256sum command. Install dependencies with ./scripts/dandoman.sh before creating backup checksums." >&2; exit 1; }
 
 backupDir="${backupDir%/}/"
 readyFile="${backupDir}READY"
-hashFile="${backupDir}SHA256SUMS"
+md5File="${backupDir}MD5SUMS"
+sha256File="${backupDir}SHA256SUMS"
 
 require_env() {
   local name=$1
@@ -35,28 +38,53 @@ require_env NETWORK
 require_env CARDANO_NODE_VERSION
 require_env CARDANO_DB_SYNC_VERSION
 
+ready_value() {
+  local key=$1
+  local sourceFile=${READY_SOURCE_FILE:-}
+  local value
+
+  if [[ -n $sourceFile && -f $sourceFile ]]; then
+    value=$(awk -F= -v key="$key" '$1 == key { sub(/^[^=]*=/, ""); print; exit }' "$sourceFile")
+    [[ -n $value ]] && { printf '%s' "$value"; return; }
+  fi
+
+  printf '%s' "${!key:-}"
+}
+
+human_size() {
+  ls -lh "$1" | awk '{print $5}'
+}
+
+write_checksum_file() {
+  local commandName=$1
+  local outFile=$2
+
+  : > "$outFile"
+  (
+    cd "$backupDir" || exit 1
+    if [[ -f READY ]]; then
+      "$commandName" READY
+    fi
+    find . -maxdepth 1 -type f -name '*.tar.gz' -printf '%f\n' | sort | while IFS= read -r fileName; do
+      "$commandName" "$fileName"
+    done
+  ) > "$outFile"
+}
+
 echo "ℹ️ Creating backup info metadata and checksums file in '$backupDir'..."
 
 cat > "$readyFile" <<EOF
-DLT=${DLT}
-NETWORK=${NETWORK}
-CARDANO_NODE_VERSION=${CARDANO_NODE_VERSION}
-CARDANO_DB_SYNC_VERSION=${CARDANO_DB_SYNC_VERSION}
+DLT=$(ready_value DLT)
+NETWORK=$(ready_value NETWORK)
+CARDANO_NODE_VERSION=$(ready_value CARDANO_NODE_VERSION)
+CARDANO_DB_SYNC_VERSION=$(ready_value CARDANO_DB_SYNC_VERSION)
 UPDATED_AT=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
 EOF
 
-# Keep the manifest compatible with plain `sha256sum -c SHA256SUMS`.
-# Only backup payloads and READY are included; SHA256SUMS never hashes itself.
-: > "$hashFile"
-(
-  cd "$backupDir" || exit 1
-  if [[ -f READY ]]; then
-    sha256sum READY
-  fi
-  find . -maxdepth 1 -type f -name '*.tar.gz' -printf '%f\n' | sort | while IFS= read -r fileName; do
-    sha256sum "$fileName"
-  done
-) > "$hashFile"
+# Keep manifests compatible with plain `md5sum -c MD5SUMS` and
+# `sha256sum -c SHA256SUMS`. Only backup payloads and READY are included.
+write_checksum_file md5sum "$md5File"
+write_checksum_file sha256sum "$sha256File"
 
 echo
 echo "ℹ️ Output:"
@@ -65,8 +93,20 @@ cat "$readyFile"
 echo
 echo "--------------"
 echo
-echo "ℹ️ Checksums file: $hashFile"
-cat "$hashFile"
+echo "ℹ️ MD5 fast-checks file: $md5File"
+cat "$md5File"
+echo
+echo "--------------"
+echo
+echo "ℹ️ SHA256 integrity checks file: $sha256File"
+cat "$sha256File"
+echo
+echo "--------------"
+echo
+echo "ℹ️ Backup file sizes:"
+find "$backupDir" -maxdepth 1 -type f -name '*.tar.gz' -printf '%f\n' | sort | while IFS= read -r fileName; do
+  echo "  $fileName - $(human_size "${backupDir}${fileName}")"
+done
 echo
 echo "ℹ️ Remove/rename $readyFile if you want to suggest other Dandelion Lite operators to avoid downloading your current backup files"
 echo "ℹ️ You can use this behaviour as a 'Maintenance Mode'"

--- a/scripts/docker/full-backup-sync.sh
+++ b/scripts/docker/full-backup-sync.sh
@@ -23,6 +23,7 @@ if [[ -n $remoteBackupUser && -z $remoteBackupPassword ]] || [[ -z $remoteBackup
 fi
 
 command -v aria2c >/dev/null 2>&1 || { echo "❌ Missing aria2c command. Install dependencies with ./scripts/dandoman.sh before downloading remote backups." >&2; exit 1; }
+command -v md5sum >/dev/null 2>&1 || { echo "❌ Missing md5sum command. Install dependencies with ./scripts/dandoman.sh before downloading remote backups." >&2; exit 1; }
 
 cd "$REPO_ROOT" || exit 1
 if [[ -f .env ]]; then
@@ -135,25 +136,51 @@ confirm_version_mismatches() {
 }
 
 manifest_hash_for() {
-  local wanted=$1
+  local manifestFile=$1
+  local wanted=$2
+  local hashPattern='^[0-9a-fA-F]{64}$'
+
+  if [[ $manifestFile == *MD5SUMS ]]; then
+    hashPattern='^[0-9a-fA-F]{32}$'
+  fi
+
   awk -v wanted="$wanted" '
-    $1 ~ /^[0-9a-fA-F]{64}$/ {
+    $1 ~ hashPattern {
       name=$0
-      sub(/^[0-9a-fA-F]{64}[[:space:]][[:space:]]?[*]?/, "", name)
+      sub(/^[0-9a-fA-F]+[[:space:]][[:space:]]?[*]?/, "", name)
       if (name == wanted || name == "./" wanted) {
         print $1
         exit
       }
     }
-  ' "$tmpDir/SHA256SUMS"
+  ' hashPattern="$hashPattern" "$manifestFile"
 }
 
 file_matches_hash() {
   local file=$1
   local hash=$2
+  local commandName=$3
 
   [[ -f $file ]] || return 1
-  printf '%s  %s\n' "$hash" "$file" | sha256sum -c --status -
+  printf '%s  %s\n' "$hash" "$file" | "$commandName" -c --status -
+}
+
+compare_final_sha256_payloads() {
+  local fileName remoteHash localHash
+
+  while IFS= read -r fileName; do
+    [[ -z $fileName ]] && continue
+    remoteHash=$(manifest_hash_for "$tmpDir/SHA256SUMS" "$fileName")
+    localHash=$(manifest_hash_for "${backupDir}SHA256SUMS" "$fileName")
+
+    [[ -n $remoteHash ]] || { echo "❌ Missing remote SHA256SUMS entry for '$fileName'." >&2; return 1; }
+    [[ -n $localHash ]] || { echo "❌ Missing local SHA256SUMS entry for '$fileName'." >&2; return 1; }
+
+    if [[ $remoteHash != "$localHash" ]]; then
+      echo "❌ SHA256SUMS mismatch for '$fileName'. Remote has '$remoteHash' but local generated '$localHash'." >&2
+      return 1
+    fi
+  done < "$tmpDir/expected-backup-files"
 }
 
 ensure_compose_volumes() {
@@ -178,6 +205,7 @@ ensure_compose_volumes() {
 echo
 echo "ℹ️ Checking remote backup metadata..."
 download_metadata READY READY || { echo "❌ Missing remote READY metadata file at '${remoteBackupURL}READY'. Remote backup repository is not ready or not reachable." >&2; exit 1; }
+download_metadata MD5SUMS MD5SUMS || { echo "❌ Missing remote MD5SUMS fast-checks file at '${remoteBackupURL}MD5SUMS'. Remote backup repository is not ready or not reachable." >&2; exit 1; }
 download_metadata SHA256SUMS SHA256SUMS || { echo "❌ Missing remote SHA256SUMS checksums file at '${remoteBackupURL}SHA256SUMS'. Remote backup repository is not ready or not reachable." >&2; exit 1; }
 parse_ready "$tmpDir/READY"
 
@@ -201,41 +229,43 @@ echo "ℹ️ Ensuring Docker Compose volumes exist before downloading backups...
 ensure_compose_volumes
 
 mkdir -p "$backupDir"
-rm -f "${backupDir}READY" "${backupDir}SHA256SUMS"
+rm -f "${backupDir}READY" "${backupDir}MD5SUMS" "${backupDir}SHA256SUMS"
 
 echo "ℹ️ Downloading backups from '$remoteBackupURL' into local dir '$backupDir'..."
 # echo "ℹ️ Will attempt to download backup files into: ${backupDir}<volume_name_without_prefix>.tar.gz"
 echo
 
 mapfile -t volumeNames < <(docker volume ls -q | sort)
+: > "$tmpDir/expected-backup-files"
 
 for volumeName in "${volumeNames[@]}"; do
   if [[ $volumeName == "$projectName"* ]]; then
     fileName=${volumeName#"$projectName"}
     backupFileName="${fileName}.tar.gz"
     targetPath="${backupDir}${backupFileName}"
-    expectedSha256=$(manifest_hash_for "$backupFileName")
+    expectedMd5=$(manifest_hash_for "$tmpDir/MD5SUMS" "$backupFileName")
 
-    [[ -z $expectedSha256 ]] && echo "❌ Missing SHA256SUMS entry for expected backup file '$backupFileName'." >&2 && exit 1
+    [[ -z $expectedMd5 ]] && echo "❌ Missing MD5SUMS entry for expected backup file '$backupFileName'." >&2 && exit 1
+    echo "$backupFileName" >> "$tmpDir/expected-backup-files"
 
-    if file_matches_hash "$targetPath" "$expectedSha256"; then
-      echo "✅ Local file already matches SHA256SUMS: $backupFileName"
+    if file_matches_hash "$targetPath" "$expectedMd5" md5sum; then
+      echo "✅ Local file already matches MD5SUMS fast-check: $backupFileName"
       echo
       continue
     fi
 
     if [[ -f $targetPath ]]; then
-      echo "ℹ️ Local file exists but does not match SHA256SUMS; trying aria2 resume before overwrite."
+      echo "ℹ️ Local file exists but does not match MD5SUMS fast-check; trying aria2 resume before overwrite."
     fi
 
     "$script_dir/backup-sync.sh" "$remoteBackupURL" "$volumeName" "$fileName" "$backupDir" "$remoteBackupUser" "$remoteBackupPassword"
 
-    if ! file_matches_hash "$targetPath" "$expectedSha256"; then
-      echo "⚠️ Resume/update completed but did not produce the expected hash; removing only '$targetPath' and retrying once." >&2
+    if ! file_matches_hash "$targetPath" "$expectedMd5" md5sum; then
+      echo "⚠️ Resume/update completed but did not produce the expected MD5 fast-check; removing only '$targetPath' and retrying once." >&2
       rm -f "$targetPath" "${targetPath}.aria2"
       "$script_dir/backup-sync.sh" "$remoteBackupURL" "$volumeName" "$fileName" "$backupDir" "$remoteBackupUser" "$remoteBackupPassword"
-      file_matches_hash "$targetPath" "$expectedSha256" || {
-        echo "❌ Downloaded backup file failed SHA256SUMS verification: $targetPath" >&2
+      file_matches_hash "$targetPath" "$expectedMd5" md5sum || {
+        echo "❌ Downloaded backup file failed MD5SUMS fast-check: $targetPath" >&2
         exit 1
       }
     fi
@@ -244,8 +274,18 @@ for volumeName in "${volumeNames[@]}"; do
   fi
 done
 
-cp "$tmpDir/READY" "${backupDir}READY"
-cp "$tmpDir/SHA256SUMS" "${backupDir}SHA256SUMS"
+echo "ℹ️ Creating local READY, MD5SUMS and SHA256SUMS files..."
+READY_SOURCE_FILE="$tmpDir/READY" "$script_dir/create-backup-checksum.sh" "$backupDir"
+
+echo "ℹ️ Verifying generated local SHA256SUMS against remote SHA256SUMS..."
+compare_final_sha256_payloads || {
+  mkdir -p "${backupDir}old"
+  mv -f "${backupDir}READY" "${backupDir}old/READY"
+  echo "⚠️ Final SHA256SUMS verification failed because local files do not match the remote hashes. READY file was moved to '${backupDir}old/READY' so other operators do not treat this published backup set as ready yet." >&2  
+  echo "ℹ️ Re-run '${script_dir}full-backup-sync.sh' to sync with remote again, this will create a READY file matching remote docker image versions" >&2    
+  echo "ℹ️ Run '${script_dir}create-backup-checksum.sh' to create the READY file matching your local backup files and docker image versions" >&2    
+  exit 1
+}
 
 echo
 echo "ℹ️ Current backup files in $backupDir:"


### PR DESCRIPTION
feat(sync): add MD5 fast-check, failure-safe READY handling, plan and docs

 - merge the fast-check backup sync plan into docs/plan-example.md
 - keep MD5SUMS as a fast precheck and SHA256SUMS as final authority
 - move READY into old/READY on final SHA verification failure
 - update backup sync docs and AGENTS guidance for the new workflow
 - keep operator-facing logging and call signatures stable
 - improved and updated README.md with latest storage requirements